### PR TITLE
(0.14.0) Update README for Vector changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,7 @@ called control plane spaces.
 In this section, we'll use our existing cluster as the one and only
 control plane space for brevity.
 
-1. Backup/restore and usage report systems are disabled for now. We'll supply
-   fake values for credentials required by those systems.
+1. Backup/restore is disabled for now. We'll supply fake credentials:
 
    ```bash
    GCP_SA_KEY="$(echo random_str | base64)"
@@ -131,15 +130,6 @@ control plane space for brevity.
    kind: Secret
    metadata:
      name: mxp-backup-sa
-     namespace: upbound-system
-   type: Opaque
-   data:
-     key.json: ${GCP_SA_KEY}
-   ---
-   apiVersion: v1
-   kind: Secret
-   metadata:
-     name: mcp-vector-sa
      namespace: upbound-system
    type: Opaque
    data:


### PR DESCRIPTION
By default we no longer need to provide cloud provider credentials to Vector.

This PR shouldn't be merged until 0.14.0 is released.