### PR TITLE
Update installation for pre-release  0.14.0-13.g2f2dceff

### DIFF
--- a/CLUSTER.md
+++ b/CLUSTER.md
@@ -78,16 +78,6 @@
    ```bash
    kubectl wait deployment -n cert-manager cert-manager-webhook --for condition=Available=True --timeout=360s
    ```
-   ```bash
-   cat <<EOF | kubectl apply -f -
-   apiVersion: cert-manager.io/v1
-   kind: ClusterIssuer
-   metadata:
-     name: selfsigned
-   spec:
-     selfSigned: {}
-   EOF
-   ```
 1. Install Crossplane.
    ```bash
    helm upgrade --install crossplane universal-crossplane \
@@ -233,16 +223,6 @@
    ```bash
    kubectl wait deployment -n cert-manager cert-manager-webhook --for condition=Available=True --timeout=360s
    ```
-   ```bash
-   cat <<EOF | kubectl apply -f -
-   apiVersion: cert-manager.io/v1
-   kind: ClusterIssuer
-   metadata:
-     name: selfsigned
-   spec:
-     selfSigned: {}
-   EOF
-   ```
 1. Install Crossplane.
    ```bash
    helm upgrade --install crossplane universal-crossplane \
@@ -283,16 +263,6 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
    ```bash
    kubectl wait deployment -n cert-manager cert-manager-webhook --for condition=Available=True --timeout=360s
    ```
-   ```bash
-   cat <<EOF | kubectl apply -f -
-   apiVersion: cert-manager.io/v1
-   kind: ClusterIssuer
-   metadata:
-     name: selfsigned
-   spec:
-     selfSigned: {}
-   EOF
-   ```
 1. Install Crossplane.
    ```bash
    helm upgrade --install crossplane universal-crossplane \
@@ -331,19 +301,6 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
    ```bash
    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
    ```
-1. Configure the self-signed certificate issuer.
-   ```bash
-   kubectl wait deployment -n cert-manager cert-manager-webhook --for condition=Available=True --timeout=360s
-   ```
-   ```bash
-   cat <<EOF | kubectl apply -f -
-   apiVersion: cert-manager.io/v1
-   kind: ClusterIssuer
-   metadata:
-     name: selfsigned
-   spec:
-     selfSigned: {}
-   EOF
    ```
 1. Install Crossplane.
    ```bash

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ tokens you have received.
    ```
 
    ```bash
-   helm -n upbound-system upgrade --install mxe oci://us-west1-docker.pkg.dev/orchestration-build/upbound-environments/mxe --version "${VERSION_NUM}" --wait \
+   helm -n upbound-system upgrade --install mxe oci://us-west1-docker.pkg.dev/orchestration-build/upbound-environments/spaces --version "${VERSION_NUM}" --wait \
      --set "ingress.host=${ROUTER_HOST}" \
      --set "clusterType=${CLUSTER_TYPE}" \
      --set "account=${UPBOUND_ACCOUNT}"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ tokens you have received.
 
 ### MXP Provisioning Machinery
 
-1. Install `mxp`. In a local cluster, you don't need to change `ROUTER_HOST` but
+1. Install `spaces`. In a local cluster, you don't need to change `ROUTER_HOST` but
    if you are deploying to a remote cluster, it needs to be **a domain you own** so
    that you can add a public DNS record for `kubectl` requests to find the router,
    hence the control plane instance.
@@ -72,7 +72,7 @@ tokens you have received.
    ```
 
    ```bash
-   helm -n upbound-system upgrade --install mxe oci://us-west1-docker.pkg.dev/orchestration-build/upbound-environments/spaces --version "${VERSION_NUM}" --wait \
+   helm -n upbound-system upgrade --install spaces oci://us-west1-docker.pkg.dev/orchestration-build/upbound-environments/spaces --version "${VERSION_NUM}" --wait \
      --set "ingress.host=${ROUTER_HOST}" \
      --set "clusterType=${CLUSTER_TYPE}" \
      --set "account=${UPBOUND_ACCOUNT}"


### PR DESCRIPTION
* Version:  0.14.0-13.g2f2dceff is in anticipation of 0.14.1.

Breaking changes:
* helm chart changed to spaces, from mxe
* values.yaml was overhauled.
* ClusterIssuers were moved to being provisioned by spaces helm chart.
* Spaces specific secrets were moved into helm chart.
* ControlPlane apiVersion was moved to spaces.upbound.io/v1alpha1