### PR TITLE
Structural Changes

### DIFF
--- a/CLUSTER.md
+++ b/CLUSTER.md
@@ -218,7 +218,7 @@ installation of Upbound Spaces.
      --repo https://kubernetes.github.io/ingress-nginx \
      --version 4.7.1 \
      --set 'controller.service.type=LoadBalancer' \
-     --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz \
+     --set 'controller.service.annotations.service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path=/healthz' \
      --wait
    ```
 

--- a/CLUSTER.md
+++ b/CLUSTER.md
@@ -93,7 +93,91 @@
      --version v1.13.2-up.1 \
      --wait
    ```
-
+1. Install Providers
+   Spaces uses Provider Helm and Provider Kubernetes internally to manage
+   resources in the cluster. We need to install them and grant permissions
+   to create resources.
+   ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: pkg.crossplane.io/v1
+   kind: Provider
+   metadata:
+     name: provider-kubernetes
+   spec:
+     package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.7.0"
+   ---
+   apiVersion: pkg.crossplane.io/v1
+   kind: Provider
+   metadata:
+     name: provider-helm
+   spec:
+     package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.14.0"
+   EOF
+   ```
+   Grant the provider pods permissions to create resources in the cluster.
+   ```bash
+   PROVIDERS=(provider-kubernetes provider-helm)
+   for PROVIDER in ${PROVIDERS[@]}; do
+     cat <<EOF | kubectl apply -f -
+   apiVersion: v1
+   kind: ServiceAccount
+   metadata:
+     name: $PROVIDER
+     namespace: upbound-system
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: $PROVIDER
+   subjects:
+     - kind: ServiceAccount
+       name: $PROVIDER
+       namespace: upbound-system
+   roleRef:
+     kind: ClusterRole
+     name: cluster-admin
+     apiGroup: rbac.authorization.k8s.io
+   ---
+   apiVersion: pkg.crossplane.io/v1alpha1
+   kind: ControllerConfig
+   metadata:
+     name: $PROVIDER-hub
+   spec:
+     serviceAccountName: $PROVIDER
+   EOF
+     kubectl patch provider.pkg.crossplane.io "${PROVIDER}" --type merge -p "{\"spec\": {\"controllerConfigRef\": {\"name\": \"$PROVIDER-hub\"}}}"
+   done
+   ```
+   Wait till the providers are ready.
+   ```bash
+   kubectl wait provider.pkg.crossplane.io/provider-helm \
+     --for=condition=Healthy \
+     --timeout=360s
+   kubectl wait provider.pkg.crossplane.io/provider-kubernetes \
+     --for=condition=Healthy \
+     --timeout=360s
+   ```
+   Create `ProviderConfig`s that will configure the providers to use
+   the cluster they're deployed into.
+   ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: helm.crossplane.io/v1beta1
+   kind: ProviderConfig
+   metadata:
+     name: upbound-cluster
+   spec:
+    credentials:
+       source: InjectedIdentity
+   ---
+   apiVersion: kubernetes.crossplane.io/v1alpha1
+   kind: ProviderConfig
+   metadata:
+     name: upbound-cluster
+   spec:
+     credentials:
+       source: InjectedIdentity
+   EOF
+   ```
  The cluster is ready! Go to [README.md](./README.md) to continue with installation of Upbound Spaces.
 
 ## Azure AKS
@@ -143,6 +227,91 @@
      --version v1.13.2-up.1 \
      --wait
    ```
+1. Install Providers
+   Spaces uses Provider Helm and Provider Kubernetes internally to manage
+   resources in the cluster. We need to install them and grant permissions
+   to create resources.
+   ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: pkg.crossplane.io/v1
+   kind: Provider
+   metadata:
+     name: provider-kubernetes
+   spec:
+     package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.7.0"
+   ---
+   apiVersion: pkg.crossplane.io/v1
+   kind: Provider
+   metadata:
+     name: provider-helm
+   spec:
+     package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.14.0"
+   EOF
+   ```
+   Grant the provider pods permissions to create resources in the cluster.
+   ```bash
+   PROVIDERS=(provider-kubernetes provider-helm)
+   for PROVIDER in ${PROVIDERS[@]}; do
+     cat <<EOF | kubectl apply -f -
+   apiVersion: v1
+   kind: ServiceAccount
+   metadata:
+     name: $PROVIDER
+     namespace: upbound-system
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: $PROVIDER
+   subjects:
+     - kind: ServiceAccount
+       name: $PROVIDER
+       namespace: upbound-system
+   roleRef:
+     kind: ClusterRole
+     name: cluster-admin
+     apiGroup: rbac.authorization.k8s.io
+   ---
+   apiVersion: pkg.crossplane.io/v1alpha1
+   kind: ControllerConfig
+   metadata:
+     name: $PROVIDER-hub
+   spec:
+     serviceAccountName: $PROVIDER
+   EOF
+     kubectl patch provider.pkg.crossplane.io "${PROVIDER}" --type merge -p "{\"spec\": {\"controllerConfigRef\": {\"name\": \"$PROVIDER-hub\"}}}"
+   done
+   ```
+   Wait till the providers are ready.
+   ```bash
+   kubectl wait provider.pkg.crossplane.io/provider-helm \
+     --for=condition=Healthy \
+     --timeout=360s
+   kubectl wait provider.pkg.crossplane.io/provider-kubernetes \
+     --for=condition=Healthy \
+     --timeout=360s
+   ```
+   Create `ProviderConfig`s that will configure the providers to use
+   the cluster they're deployed into.
+   ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: helm.crossplane.io/v1beta1
+   kind: ProviderConfig
+   metadata:
+     name: upbound-cluster
+   spec:
+    credentials:
+       source: InjectedIdentity
+   ---
+   apiVersion: kubernetes.crossplane.io/v1alpha1
+   kind: ProviderConfig
+   metadata:
+     name: upbound-cluster
+   spec:
+     credentials:
+       source: InjectedIdentity
+   EOF
+   ```
 
 The cluster is ready! Go to [README.md](./README.md) to continue with installation of Upbound Spaces.
 
@@ -182,6 +351,91 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
      --namespace upbound-system --create-namespace \
      --version v1.13.2-up.1 \
      --wait
+   ```
+1. Install Providers
+   Spaces uses Provider Helm and Provider Kubernetes internally to manage
+   resources in the cluster. We need to install them and grant permissions
+   to create resources.
+   ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: pkg.crossplane.io/v1
+   kind: Provider
+   metadata:
+     name: provider-kubernetes
+   spec:
+     package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.7.0"
+   ---
+   apiVersion: pkg.crossplane.io/v1
+   kind: Provider
+   metadata:
+     name: provider-helm
+   spec:
+     package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.14.0"
+   EOF
+   ```
+   Grant the provider pods permissions to create resources in the cluster.
+   ```bash
+   PROVIDERS=(provider-kubernetes provider-helm)
+   for PROVIDER in ${PROVIDERS[@]}; do
+     cat <<EOF | kubectl apply -f -
+   apiVersion: v1
+   kind: ServiceAccount
+   metadata:
+     name: $PROVIDER
+     namespace: upbound-system
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: $PROVIDER
+   subjects:
+     - kind: ServiceAccount
+       name: $PROVIDER
+       namespace: upbound-system
+   roleRef:
+     kind: ClusterRole
+     name: cluster-admin
+     apiGroup: rbac.authorization.k8s.io
+   ---
+   apiVersion: pkg.crossplane.io/v1alpha1
+   kind: ControllerConfig
+   metadata:
+     name: $PROVIDER-hub
+   spec:
+     serviceAccountName: $PROVIDER
+   EOF
+     kubectl patch provider.pkg.crossplane.io "${PROVIDER}" --type merge -p "{\"spec\": {\"controllerConfigRef\": {\"name\": \"$PROVIDER-hub\"}}}"
+   done
+   ```
+   Wait till the providers are ready.
+   ```bash
+   kubectl wait provider.pkg.crossplane.io/provider-helm \
+     --for=condition=Healthy \
+     --timeout=360s
+   kubectl wait provider.pkg.crossplane.io/provider-kubernetes \
+     --for=condition=Healthy \
+     --timeout=360s
+   ```
+   Create `ProviderConfig`s that will configure the providers to use
+   the cluster they're deployed into.
+   ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: helm.crossplane.io/v1beta1
+   kind: ProviderConfig
+   metadata:
+     name: upbound-cluster
+   spec:
+    credentials:
+       source: InjectedIdentity
+   ---
+   apiVersion: kubernetes.crossplane.io/v1alpha1
+   kind: ProviderConfig
+   metadata:
+     name: upbound-cluster
+   spec:
+     credentials:
+       source: InjectedIdentity
+   EOF
    ```
 
 The cluster is ready! Go to [README.md](./README.md) to continue with installation of Upbound Spaces.
@@ -224,6 +478,91 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
      --namespace upbound-system --create-namespace \
      --version v1.13.2-up.1 \
      --wait
+   ```
+1. Install Providers
+   Spaces uses Provider Helm and Provider Kubernetes internally to manage
+   resources in the cluster. We need to install them and grant permissions
+   to create resources.
+   ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: pkg.crossplane.io/v1
+   kind: Provider
+   metadata:
+     name: provider-kubernetes
+   spec:
+     package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.7.0"
+   ---
+   apiVersion: pkg.crossplane.io/v1
+   kind: Provider
+   metadata:
+     name: provider-helm
+   spec:
+     package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.14.0"
+   EOF
+   ```
+   Grant the provider pods permissions to create resources in the cluster.
+   ```bash
+   PROVIDERS=(provider-kubernetes provider-helm)
+   for PROVIDER in ${PROVIDERS[@]}; do
+     cat <<EOF | kubectl apply -f -
+   apiVersion: v1
+   kind: ServiceAccount
+   metadata:
+     name: $PROVIDER
+     namespace: upbound-system
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: $PROVIDER
+   subjects:
+     - kind: ServiceAccount
+       name: $PROVIDER
+       namespace: upbound-system
+   roleRef:
+     kind: ClusterRole
+     name: cluster-admin
+     apiGroup: rbac.authorization.k8s.io
+   ---
+   apiVersion: pkg.crossplane.io/v1alpha1
+   kind: ControllerConfig
+   metadata:
+     name: $PROVIDER-hub
+   spec:
+     serviceAccountName: $PROVIDER
+   EOF
+     kubectl patch provider.pkg.crossplane.io "${PROVIDER}" --type merge -p "{\"spec\": {\"controllerConfigRef\": {\"name\": \"$PROVIDER-hub\"}}}"
+   done
+   ```
+   Wait till the providers are ready.
+   ```bash
+   kubectl wait provider.pkg.crossplane.io/provider-helm \
+     --for=condition=Healthy \
+     --timeout=360s
+   kubectl wait provider.pkg.crossplane.io/provider-kubernetes \
+     --for=condition=Healthy \
+     --timeout=360s
+   ```
+   Create `ProviderConfig`s that will configure the providers to use
+   the cluster they're deployed into.
+   ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: helm.crossplane.io/v1beta1
+   kind: ProviderConfig
+   metadata:
+     name: upbound-cluster
+   spec:
+    credentials:
+       source: InjectedIdentity
+   ---
+   apiVersion: kubernetes.crossplane.io/v1alpha1
+   kind: ProviderConfig
+   metadata:
+     name: upbound-cluster
+   spec:
+     credentials:
+       source: InjectedIdentity
+   EOF
    ```
 
  The cluster is ready! Go to [README.md](./README.md) to continue with installation of Upbound Spaces.

--- a/CLUSTER.md
+++ b/CLUSTER.md
@@ -93,10 +93,9 @@
      --version v1.13.2-up.1 \
      --wait
    ```
-1. Install Providers
-   Spaces uses Provider Helm and Provider Kubernetes internally to manage
-   resources in the cluster. We need to install them and grant permissions
-   to create resources.
+1. Install Provider Helm and Provider Kubernetes. Spaces uses these providers
+   internally to manage resources in the cluster. We need to install these
+   providers and grant necessary permissions to create resources.
    ```bash
    cat <<EOF | kubectl apply -f -
    apiVersion: pkg.crossplane.io/v1
@@ -104,14 +103,14 @@
    metadata:
      name: provider-kubernetes
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.7.0"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.9.0"
    ---
    apiVersion: pkg.crossplane.io/v1
    kind: Provider
    metadata:
      name: provider-helm
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.14.0"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.15.0"
    EOF
    ```
    Grant the provider pods permissions to create resources in the cluster.
@@ -178,7 +177,8 @@
        source: InjectedIdentity
    EOF
    ```
- The cluster is ready! Go to [README.md](./README.md) to continue with installation of Upbound Spaces.
+The cluster is ready! Go to [README.md](./README.md) to continue with
+installation of Upbound Spaces.
 
 ## Azure AKS
 1. export common variables
@@ -238,10 +238,9 @@
      --version v1.13.2-up.1 \
      --wait
    ```
-1. Install Providers
-   Spaces uses Provider Helm and Provider Kubernetes internally to manage
-   resources in the cluster. We need to install them and grant permissions
-   to create resources.
+1. Install Provider Helm and Provider Kubernetes. Spaces uses these providers
+   internally to manage resources in the cluster. We need to install these
+   providers and grant necessary permissions to create resources.
    ```bash
    cat <<EOF | kubectl apply -f -
    apiVersion: pkg.crossplane.io/v1
@@ -249,14 +248,14 @@
    metadata:
      name: provider-kubernetes
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.7.0"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.9.0"
    ---
    apiVersion: pkg.crossplane.io/v1
    kind: Provider
    metadata:
      name: provider-helm
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.14.0"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.15.0"
    EOF
    ```
    Grant the provider pods permissions to create resources in the cluster.
@@ -324,7 +323,8 @@
    EOF
    ```
 
-The cluster is ready! Go to [README.md](./README.md) to continue with installation of Upbound Spaces.
+The cluster is ready! Go to [README.md](./README.md) to continue with
+installation of Upbound Spaces.
 
 ## Google Cloud GKE
 1. export common variables
@@ -339,7 +339,7 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
      --enable-network-policy \
      --num-nodes=3 \
      --zone=${LOCATION} \
-     --machine-type=e2-standard-16
+     --machine-type=e2-standard-4
    ```
 
 1. Acquire updated kubeconfig
@@ -373,10 +373,9 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
      --version v1.13.2-up.1 \
      --wait
    ```
-1. Install Providers
-   Spaces uses Provider Helm and Provider Kubernetes internally to manage
-   resources in the cluster. We need to install them and grant permissions
-   to create resources.
+1. Install Provider Helm and Provider Kubernetes. Spaces uses these providers
+   internally to manage resources in the cluster. We need to install these
+   providers and grant necessary permissions to create resources.
    ```bash
    cat <<EOF | kubectl apply -f -
    apiVersion: pkg.crossplane.io/v1
@@ -384,14 +383,14 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
    metadata:
      name: provider-kubernetes
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.7.0"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.9.0"
    ---
    apiVersion: pkg.crossplane.io/v1
    kind: Provider
    metadata:
      name: provider-helm
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.14.0"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.15.0"
    EOF
    ```
    Grant the provider pods permissions to create resources in the cluster.
@@ -459,7 +458,8 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
    EOF
    ```
 
-The cluster is ready! Go to [README.md](./README.md) to continue with installation of Upbound Spaces.
+The cluster is ready! Go to [README.md](./README.md) to continue with
+installation of Upbound Spaces.
 
 ## kind Cluster
 
@@ -511,10 +511,9 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
      --version v1.13.2-up.1 \
      --wait
    ```
-1. Install Providers
-   Spaces uses Provider Helm and Provider Kubernetes internally to manage
-   resources in the cluster. We need to install them and grant permissions
-   to create resources.
+1. Install Provider Helm and Provider Kubernetes. Spaces uses these providers
+   internally to manage resources in the cluster. We need to install these
+   providers and grant necessary permissions to create resources.
    ```bash
    cat <<EOF | kubectl apply -f -
    apiVersion: pkg.crossplane.io/v1
@@ -522,14 +521,14 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
    metadata:
      name: provider-kubernetes
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.7.0"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.9.0"
    ---
    apiVersion: pkg.crossplane.io/v1
    kind: Provider
    metadata:
      name: provider-helm
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.14.0"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.15.0"
    EOF
    ```
    Grant the provider pods permissions to create resources in the cluster.
@@ -597,4 +596,5 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
    EOF
    ```
 
- The cluster is ready! Go to [README.md](./README.md) to continue with installation of Upbound Spaces.
+ The cluster is ready! Go to [README.md](./README.md) to continue with
+ installation of Upbound Spaces.

--- a/CLUSTER.md
+++ b/CLUSTER.md
@@ -211,6 +211,17 @@
    az aks get-credentials --resource-group ${RESOURCE_GROUP_NAME} --name ${CLUSTER_NAME}
    ```
 
+1. Install ingress-nginx.
+   ```bash
+   helm upgrade --install ingress-nginx ingress-nginx \
+     --create-namespace --namespace ingress-nginx \
+     --repo https://kubernetes.github.io/ingress-nginx \
+     --version 4.7.1 \
+     --set 'controller.service.type=LoadBalancer' \
+     --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz \
+     --wait
+   ```
+
 1. Install cert-manager.
    ```bash
    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.3/cert-manager.yaml
@@ -334,6 +345,16 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
 1. Acquire updated kubeconfig
    ```bash
    gcloud container clusters get-credentials ${CLUSTER_NAME} --zone=${LOCATION}
+   ```
+
+1. Install ingress-nginx.
+   ```bash
+   helm upgrade --install ingress-nginx ingress-nginx \
+     --create-namespace --namespace ingress-nginx \
+     --repo https://kubernetes.github.io/ingress-nginx \
+     --version 4.7.1 \
+     --set 'controller.service.type=LoadBalancer' \
+     --wait
    ```
 
 1. Install cert-manager.
@@ -469,6 +490,17 @@ The cluster is ready! Go to [README.md](./README.md) to continue with installati
    ```
    ```bash
    kubectl wait deployment -n cert-manager cert-manager-webhook --for condition=Available=True --timeout=360s
+   ```
+
+1. Install ingress-nginx.
+   ```bash
+   kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.1/deploy/static/provider/kind/deploy.yaml
+   ```
+   ```bash
+   kubectl wait --namespace ingress-nginx \
+     --for=condition=ready pod \
+     --selector=app.kubernetes.io/component=controller \
+     --timeout=90s 
    ```
 
 1. Install Crossplane.

--- a/README.md
+++ b/README.md
@@ -31,30 +31,23 @@ export UPBOUND_ACCOUNT=<your upbound account>
 First, you need to create image pull secrets with the Google Service Account
 tokens you have received.
 
-1. Create an image pull secret to pull images from GCR. There are two ways to
-   authenticate, you need to follow only one of the following instructions:
+1. Export the path of the service account token JSON file.
+   ```bash
+   # Change the path to where you saved the token.
+   export GCP_TOKEN_PATH="THE PATH TO YOUR GCRTOKEN FILE"
+   ```
+1. Create an image pull secret so that the cluster can pull Upbound Spaces images.
+   ```bash
+   kubectl -n upbound-system create secret docker-registry upbound-pull-secret \
+     --docker-server=https://us-west1-docker.pkg.dev \
+     --docker-username=_json_key \
+     --docker-password="$(cat $GCP_TOKEN_PATH)"
+   ```
 
-   - (Service Account Token) Save the token to a file named `gcrtoken.json`.
-
-     ```bash
-     # Change the path to where you saved the token.
-     export GCP_TOKEN_PATH="THE PATH TO YOUR GCRTOKEN FILE"
-     ```
-
-     Run the following command.
-
-     ```bash
-     kubectl -n upbound-system create secret docker-registry upbound-pull-secret \
-       --docker-server=https://us-west1-docker.pkg.dev \
-       --docker-username=_json_key \
-       --docker-password="$(cat $GCP_TOKEN_PATH)"
-     ```
-
-1. Log in with Helm to be able to pull chart images from GCR.
-   - (Service Account Token) Run the following command.
-     ```bash
-     cat $GCP_TOKEN_PATH | helm registry login us-west1-docker.pkg.dev -u _json_key --password-stdin
-     ```
+1. Log in with Helm to be able to pull chart images for the installation commands.
+   ```bash
+   cat $GCP_TOKEN_PATH | helm registry login us-west1-docker.pkg.dev -u _json_key --password-stdin
+   ```
 
 #### Set the target version
 

--- a/README.md
+++ b/README.md
@@ -78,56 +78,6 @@ You sould now be able to jump to [Create your first control plane](#create-your-
 
 ### Using Helm
 
-#### Provision Ingress to the Cluster.
-
-1. (Non-kind Cluster) Create an Ingress:
-   By default, an ingress is not created; any Kubernetes ingress provider should work just fine.
-   However, spaces expects that a Service pointing to the ingress controller/pod be:
-   - in the `ingress-nginx` namespace
-   - be named `ingress-nginx-controller`
-   Note: we expect that this requirement will be changed in the future.
-
-   If you need an Ingress provider, Upbound recommends Nginx as a starting point. To install:
-   ```bash
-   helm repo add nginx https://kubernetes.github.io/ingress-nginx
-   helm repo update
-   helm install -n ingress-nginx --create-namespace \
-        ingress-nginx nginx/ingress-nginx
-    ```
-
-   Then, to create the Service, run:
-   ```bash
-   cat <<EOF | eksctl create cluster -f -
-   apiVersion: v1
-   kind: Service
-   metadata:
-     name: ingress-nginx-controller
-     namespace: ingress-nginx
-   spec:
-     allocateLoadBalancerNodePorts: true
-     externalTrafficPolicy: Cluster
-     internalTrafficPolicy: Cluster
-     ipFamilies:
-     - IPv4
-     ipFamilyPolicy: SingleStack
-     ports:
-     - name: http
-       port: 80
-       protocol: TCP
-       targetPort: http
-     - name: https
-       port: 443
-       protocol: TCP
-       targetPort: https
-     selector:
-       app.kubernetes.io/component: controller
-       app.kubernetes.io/instance: nginx-ingress
-       app.kubernetes.io/name: ingress-nginx
-     sessionAffinity: None
-     type: LoadBalancer
-   EOF
-   ```
-
 #### Helm install
 
 1. Install `spaces`. In a local cluster, you don't need to change `ROUTER_HOST` 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ tokens you have received.
 
 This is the Spaces version to install.
 ```bash
-export VERSION_NUM=0.15.0
+export VERSION_NUM=0.15.1
 ```
 
 #### Set the router host and cluster type
@@ -62,7 +62,7 @@ The `ROUTER_HOST` is the domain name that will be used to access the control
 plane instances. It will be used by the ingress controller to route requests.
 Unless you're using a `kind` cluster, you will need to add DNS entries for this
 domain to point to the load balancer deployed by the ingress controller, so make
-sure you use one that you own.
+sure you use a domain that you own.
 ```bash
 # For kind
 export ROUTER_HOST=proxy.upbound-127.0.0.1.nip.io
@@ -122,8 +122,8 @@ You should now be able to jump to [Create your first control plane](#create-your
 #### Setup
 
 Up CLI installs all the pre-requisites to your cluster before starting the
-installation. With Helm method, you need install them separately which gives you
-more control over the installation process.
+installation. With Helm method, you need to install them separately which gives
+you more control over the installation process.
 
 Follow instructions [here](./CLUSTER.md) to prepare your cluster.
 
@@ -131,10 +131,13 @@ Follow instructions [here](./CLUSTER.md) to prepare your cluster.
 1. Install `spaces`.
 
    ```bash
-   helm -n upbound-system upgrade --install spaces oci://us-west1-docker.pkg.dev/orchestration-build/upbound-environments/spaces --version "${VERSION_NUM}" --wait \
+   helm -n upbound-system upgrade --install spaces \
+     oci://us-west1-docker.pkg.dev/orchestration-build/upbound-environments/spaces \
+     --version "${VERSION_NUM}" \
      --set "ingress.host=${ROUTER_HOST}" \
      --set "clusterType=${CLUSTER_TYPE}" \
-     --set "account=${UPBOUND_ACCOUNT}"
+     --set "account=${UPBOUND_ACCOUNT}" \
+     --wait
    ```
 
 1. (Non-kind Cluster) Create a DNS record for the load balancer of the public


### PR DESCRIPTION
* `CLUSTER.md` is referenced only under Helm installation now since up CLI does all of them on its own, except cluster creation.
* Provider installations are moved to `CLUSTER.md`.
* `ingress-nginx` installations are added to all cluster types.
* Updated cluster instructions to have a smaller instance type.
* Update provider versions.
  * This required bumping spaces to v0.15.1

## Testing

* AWS EKS using Helm confirmed with a git source.
* Google GKE using Helm confirmed with a git source.
* Azure AKS using Helm confirmed with a git source.
* kind using Helm confirmed with a git source.